### PR TITLE
Fixes #33 as well as an issue where signature cards not containing the entire certificate chains do not work due to a trust error

### DIFF
--- a/jsignpdf-pades/src/main/java/com/github/intoolswetrust/jsignpdf/pades/SignerLogic.java
+++ b/jsignpdf-pades/src/main/java/com/github/intoolswetrust/jsignpdf/pades/SignerLogic.java
@@ -24,6 +24,8 @@ import java.util.logging.Level;
 import javax.naming.ldap.LdapName;
 import javax.naming.ldap.Rdn;
 
+import eu.europa.esig.dss.service.crl.OnlineCRLSource;
+import eu.europa.esig.dss.service.ocsp.OnlineOCSPSource;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pdfbox.Loader;
@@ -207,6 +209,9 @@ public class SignerLogic {
                 }
 
                 CommonCertificateVerifier verifier = new CommonCertificateVerifier();
+                verifier.setCheckRevocationForUntrustedChains(true);
+                verifier.setOcspSource(new OnlineOCSPSource());
+                verifier.setCrlSource(new OnlineCRLSource());
                 PAdESService service = new PAdESService(verifier);
 
                 // Configure TSA


### PR DESCRIPTION
This PR fixes issue #33 as well as an issue where signature cards not containing the entire certificate chain do not work due to a trust error.

It achieves this by enabling online CRL and OCSP retrieval as well as enabling revocation checking for untrusted certificates. This should not have any security implications.